### PR TITLE
feat: added notification settings

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -223,3 +223,18 @@ variable "MILVUS_DIMENSION" {
     type        = string
     description = "Milvus dimension"
 }
+
+variable "GOOGLE_APPLICATION_CREDENTIALS_PATH" {
+    type        = string
+    description = "Google application credentials path for fcm"
+}
+
+variable "DEEP_LINK_BASE" {
+    type        = string
+    description = "Deep link base"
+}
+
+variable "SSM_PARAMETER_SERVICE_ACCOUNT" {
+  type = string
+  description = "Service account in parameter store"
+}


### PR DESCRIPTION
1. parameter store에 json 파일을 저장
    - 이때 private key에 있는 이스케이프 문자 \n -> \\n으로 바꾸어서 넣어야 golang 애플리케이션에서 파싱할 수 있음
2. parameter store에서 json 읽어서 GOOGLE_APPLICATION_CREDENTIALS_CONTENT에 secret 환경변수로 저장 
3. GOOGLE_APPLICATION_CREDENTIALS는 파일이 저장될 경로인데, 여기다가 command를 통해 GOOGLE_APPLICATION_CREDENTIALS_CONTENT 내용을 담은 json 파일을 생성
    - 이때, task definition의 command 때문에 도커 파일의 CMD가 실행되지 않는 문제가 있었음
    - gpt한테 물어보니까 task definition의 cmd가 도커 파일의 cmd를 덮어쓴거라 하긴하던데.. 아무튼 그래서 task definition의 cmd에다가 go run main.go 같이 추가해줌
    - 도커파일 고치는것보단 task definition에다가 쓴느게 덜 종속적일것 같아서? 어차피 도커로 실행할땐 GOOGLE_APPLICATION_CREDENTIALS_CONTENT까 필요없이 GOOGLE_APPLICATION_CREDENTIALS만 실행하면 되니깐'
4. 앱 실행하면 fcm sdk에서 알잘딱하게 GOOGLE_APPLICATION_CREDENTIALS 경로 읽어서 세팅함